### PR TITLE
feat: Add GitHub Actions for CI/CD and fix test permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Build with javac
+      run: |
+        set -e
+        mkdir -p out
+        javac -d out $(find src -name "*.java") $(find tests -name "*.java")
+    - name: Run tests
+      run: |
+        chmod +x ./test.sh
+        export CLASSPATH=out
+        ./test.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy to Docker Hub
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Build with javac
+      run: |
+        set -e
+        mkdir -p out
+        javac -d out $(find src -name "*.java")
+
+    - name: Create jar file
+      run: |
+        set -e
+        jar -cvf prithvi.jar -C out .
+        ls -lh prithvi.jar
+        jar -tf prithvi.jar
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: |
+          psidharth/prithvi-docker:latest
+          psidharth/prithvi-docker:${{ github.sha }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/amd64,linux/arm64
+
+    - name: Sanity check: run Docker image
+      run: |
+        docker pull psidharth/prithvi-docker:${{ github.sha }}
+        docker run --rm psidharth/prithvi-docker:${{ github.sha }} java -jar prithvi.jar


### PR DESCRIPTION
This commit introduces GitHub Actions workflows for continuous integration (CI) and continuous deployment (CD).
- ci.yml: Configures a CI pipeline to build the project and run tests on push and pull requests to the main branch.
- deploy.yml: Configures a CD pipeline to build and push Docker images to Docker Hub on push to the main branch. It also includes a fix to grant execute permissions to the 'test.sh' script in the CI workflow, resolving a 'Permission denied' error.

the issue i tried to solve is #5 
![prithvi](https://github.com/user-attachments/assets/b9e2faef-7bee-44ab-aef8-739c90f666b2)
